### PR TITLE
Add option to stop JDBC_PING from registering a shutdown hook

### DIFF
--- a/src/org/jgroups/protocols/JDBC_PING.java
+++ b/src/org/jgroups/protocols/JDBC_PING.java
@@ -1,25 +1,18 @@
 package org.jgroups.protocols;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
-
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.sql.DataSource;
-
 import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.PhysicalAddress;
 import org.jgroups.View;
 import org.jgroups.annotations.Property;
-import org.jgroups.protocols.Discovery;
-import org.jgroups.protocols.PingData;
 import org.jgroups.util.Responses;
 import org.jgroups.util.UUID;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.List;
 
 /**
  * <p>Discovery protocol using a JDBC connection to a shared database.


### PR DESCRIPTION
In managed containers (Spring ApplicationContext, J2EE ServletContext) the JConnector will be shut down gracefully when the context is closed.

Shutdown hooks registered with the JVM will result in ugly errors when the JVM exists (classes needed to execute it have been unloaded). They also cause memory leaks since they can't be unloaded by the Tomcat (or similar) server.

This adds a configuration option `register_shutdown_hook` to conditionally disable the creation of a shutdown hook. The default is `true` to maintain the current behavior.
